### PR TITLE
4: Adds context path whitelist configuration to ToolsConfigPagePersistenceStrategy

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -27,6 +27,9 @@
       <action type="update" dev="sseifert">
         Switch to AEM 6.5.17 as minimum version.
       </action>
+      <action type="update" dev="cnagel" issue="4">
+        Adds context path whitelist to ToolsConfigPagePersistenceStrategy configuration.
+      </action>
     </release>
 
     <release version="1.9.4" date="2023-10-17">

--- a/changes.xml
+++ b/changes.xml
@@ -28,7 +28,8 @@
         Switch to AEM 6.5.17 as minimum version.
       </action>
       <action type="update" dev="cnagel" issue="4">
-        Adds context path whitelist to ToolsConfigPagePersistenceStrategy configuration.
+        Adds context path allow list to ToolsConfigPagePersistenceStrategy configuration.
+        This is a (minor) breaking change - by default only configurations stored in /content will work with this strategy.
       </action>
     </release>
 

--- a/src/main/java/io/wcm/caconfig/extensions/persistence/impl/ToolsConfigPagePersistenceStrategy.java
+++ b/src/main/java/io/wcm/caconfig/extensions/persistence/impl/ToolsConfigPagePersistenceStrategy.java
@@ -102,9 +102,9 @@ public class ToolsConfigPagePersistenceStrategy implements ConfigurationPersiste
         description = "Relative path to the configuration page content.")
     String relativeConfigPath() default "/tools/config/jcr:content";
 
-    @AttributeDefinition(name = "Context path whitelist",
-            description = "Expression to match context paths. Context paths matching this expression are allowed. Use groups to reference them in configPathPatterns.")
-    String contextPathRegex();
+    @AttributeDefinition(name = "Context path allow list",
+            description = "Expression to match context paths. Context paths matching this expression are allowed.")
+    String contextPathRegex() default "^/content(/.+)$";
 
   }
 
@@ -311,10 +311,10 @@ public class ToolsConfigPagePersistenceStrategy implements ConfigurationPersiste
 
   @SuppressWarnings("unused")
   private boolean isEnabledAndParamsValid(final Resource contentResource, final Collection<String> bucketNames, final String configName) {
-    return enabled && contentResource != null && isContextPathWhitelisted(contentResource.getPath());
+    return enabled && contentResource != null && isContextPathAllowed(contentResource.getPath());
   }
 
-  private boolean isContextPathWhitelisted(String contextPath) {
+  private boolean isContextPathAllowed(String contextPath) {
     return contextPathPattern == null || contextPathPattern.matcher(contextPath).matches();
   }
 

--- a/src/main/java/io/wcm/caconfig/extensions/persistence/impl/ToolsConfigPagePersistenceStrategy.java
+++ b/src/main/java/io/wcm/caconfig/extensions/persistence/impl/ToolsConfigPagePersistenceStrategy.java
@@ -102,6 +102,10 @@ public class ToolsConfigPagePersistenceStrategy implements ConfigurationPersiste
         description = "Relative path to the configuration page content.")
     String relativeConfigPath() default "/tools/config/jcr:content";
 
+    @AttributeDefinition(name = "Context path whitelist",
+            description = "Expression to match context paths. Context paths matching this expression are allowed. Use groups to reference them in configPathPatterns.")
+    String contextPathRegex();
+
   }
 
   private static final String DEFAULT_CONFIG_NODE_TYPE = NT_UNSTRUCTURED;
@@ -111,6 +115,7 @@ public class ToolsConfigPagePersistenceStrategy implements ConfigurationPersiste
 
   private boolean enabled;
   private Pattern configPathPattern;
+  private Pattern contextPathPattern;
   private Config config;
 
   @Reference
@@ -126,6 +131,7 @@ public class ToolsConfigPagePersistenceStrategy implements ConfigurationPersiste
   void activate(Config value) {
     this.enabled = value.enabled();
     this.configPathPattern = loadConfigPathPattern(value);
+    this.contextPathPattern = loadContextPathPattern(value);
     this.config = value;
   }
 
@@ -133,6 +139,13 @@ public class ToolsConfigPagePersistenceStrategy implements ConfigurationPersiste
     String relativeConfigPath = value.relativeConfigPath();
     return enabled && StringUtils.isNotBlank(relativeConfigPath)
             ? Pattern.compile(String.format("^.*%s(/.*)?$", relativeConfigPath))
+            : null;
+  }
+
+  private @Nullable Pattern loadContextPathPattern(Config value) {
+    String contextPathRegex = value.contextPathRegex();
+    return enabled && StringUtils.isNotBlank(contextPathRegex)
+            ? Pattern.compile(contextPathRegex)
             : null;
   }
 
@@ -298,7 +311,11 @@ public class ToolsConfigPagePersistenceStrategy implements ConfigurationPersiste
 
   @SuppressWarnings("unused")
   private boolean isEnabledAndParamsValid(final Resource contentResource, final Collection<String> bucketNames, final String configName) {
-    return enabled && contentResource != null;
+    return enabled && contentResource != null && isContextPathWhitelisted(contentResource.getPath());
+  }
+
+  private boolean isContextPathWhitelisted(String contextPath) {
+    return contextPathPattern == null || contextPathPattern.matcher(contextPath).matches();
   }
 
   private String buildResourcePath(String path, String name) {


### PR DESCRIPTION
Adds context path whitelist to ToolsConfigPagePersistenceStrategy configuration.

Fixes https://github.com/wcm-io/io.wcm.caconfig.extensions/issues/4