### PR TITLE
Unable to publish/preview new assets when quick publish from tools config page editor

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,7 +23,11 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
-    <release version="1.9.8" date="not released">
+    <release version="1.10.0" date="not released">
+      <action type="add" dev="srikanthgurram" issue="7">
+        Configuration Reference Provider: Check for asset reference contained in the Context-Aware configurations and add them to the list of reference to check for publication.
+        This feature is disabled by default, and can be enabled by OSGi configuration.
+      </action>
       <action type="fix" dev="srikanthgurram" issue="8">
         Saving of Context-Aware configuration collections: Update last modified date of item pages only if the configuration of it has actually changed.
       </action>

--- a/src/main/java/io/wcm/caconfig/extensions/references/impl/AssetRefereneDetector.java
+++ b/src/main/java/io/wcm/caconfig/extensions/references/impl/AssetRefereneDetector.java
@@ -1,0 +1,140 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caconfig.extensions.references.impl;
+
+import static com.day.cq.dam.api.DamConstants.MOUNTPOINT_ASSETS;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.day.cq.dam.api.Asset;
+import com.day.cq.wcm.api.Page;
+
+/**
+ * Recursively scans all string and string array properties in all resources of the given configuration page
+ * to check for asset references.
+ */
+class AssetRefereneDetector {
+
+  private final Page configPage;
+  private final Resource configResource;
+  private final ResourceResolver resourceResolver;
+  private final List<Asset> assets = new ArrayList<>();
+
+  private static final Pattern ASSET_PATH = Pattern.compile("^" + MOUNTPOINT_ASSETS + "/.*$");
+  private static final Logger log = LoggerFactory.getLogger(AssetRefereneDetector.class);
+
+  /**
+   * @param configPage Configuration page (must have a content resource).
+   */
+  AssetRefereneDetector(@NotNull Page configPage) {
+    this.configPage = configPage;
+    this.configResource = configPage.getContentResource();
+    this.resourceResolver = configResource.getResourceResolver();
+  }
+
+  /**
+   * @return List of all assets referenced in the configuration page.
+   */
+  List<Asset> getReferencedAssets() {
+    assets.clear();
+    findAssetReferencesRecursively(configResource);
+    return assets;
+  }
+
+  /**
+   * Recurse through all child resources of the given resource.
+   * @param resource Resource
+   */
+  private void findAssetReferencesRecursively(@NotNull Resource resource) {
+    findAssetReferences(resource);
+    resource.getChildren().forEach(this::findAssetReferencesRecursively);
+  }
+
+  /**
+   * Find asset references in all properties of the given resource.
+   * @param resource Resource
+   */
+  private void findAssetReferences(@NotNull Resource resource) {
+    ValueMap props = resource.getValueMap();
+    assets.addAll(props.values().stream()
+        .flatMap(this::getAssetsIfAssetReference)
+        .collect(Collectors.toList()));
+  }
+
+  /**
+   * Checks if the value is string which might be asset reference, or an array containing a string asset reference.
+   * @param value Value
+   * @return Found referenced assets
+   */
+  private Stream<Asset> getAssetsIfAssetReference(@Nullable Object value) {
+    List<Asset> result = new ArrayList<>();
+    if (value instanceof String) {
+      getAssetIfAssetReference((String)value).ifPresent(result::add);
+    }
+    else if (value != null && value.getClass().isArray()) {
+      int length = Array.getLength(value);
+      for (int i = 0; i < length; i++) {
+        Object itemValue = Array.get(value, i);
+        if (itemValue instanceof String) {
+          getAssetIfAssetReference((String)itemValue).ifPresent(result::add);
+        }
+      }
+    }
+    return result.stream();
+  }
+
+  /**
+   * Checks if the given string points to an asset.
+   * @param value String value
+   * @return Asset if string is a valid asset reference.
+   */
+  private Optional<Asset> getAssetIfAssetReference(@NotNull String value) {
+    if (isAssetReference(value)) {
+      Resource resource = resourceResolver.getResource(value);
+      if (resource != null) {
+        Asset asset = resource.adaptTo(Asset.class);
+        if (asset != null) {
+          log.trace("Found asset reference {} for resource {}", configPage.getPath(), resource.getPath());
+          return Optional.of(asset);
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+  static boolean isAssetReference(@NotNull String value) {
+    return ASSET_PATH.matcher(value).matches();
+  }
+
+}

--- a/src/main/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider.java
+++ b/src/main/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider.java
@@ -76,7 +76,7 @@ import com.day.cq.wcm.api.reference.ReferenceProvider;
 public class ConfigurationReferenceProvider implements ReferenceProvider {
 
   @ObjectClassDefinition(name = "wcm.io Context-Aware Configuration Reference Provider",
-          description = "Allows to resolve references from resources to their Context-Aware configurations & assets, for example during page activation.")
+      description = "Allows to resolve references from resources to their Context-Aware configurations & assets, for example during page activation.")
   @interface Config {
 
     @AttributeDefinition(name = "Enabled",

--- a/src/main/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider.java
+++ b/src/main/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider.java
@@ -76,7 +76,8 @@ import com.day.cq.wcm.api.reference.ReferenceProvider;
 public class ConfigurationReferenceProvider implements ReferenceProvider {
 
   @ObjectClassDefinition(name = "wcm.io Context-Aware Configuration Reference Provider",
-      description = "Allows to resolve references from resources to their Context-Aware configurations & assets, for example during page activation.")
+      description = "Allows to resolve references from resources to their Context-Aware configuration pages "
+          + "and referenced assets, for example during page activation.")
   @interface Config {
 
     @AttributeDefinition(name = "Enabled",

--- a/src/test/java/io/wcm/caconfig/extensions/references/impl/AssetRefereneDetectorTest.java
+++ b/src/test/java/io/wcm/caconfig/extensions/references/impl/AssetRefereneDetectorTest.java
@@ -1,0 +1,97 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caconfig.extensions.references.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.day.cq.dam.api.Asset;
+import com.day.cq.wcm.api.Page;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import io.wcm.wcm.commons.contenttype.ContentType;
+
+@ExtendWith(AemContextExtension.class)
+class AssetRefereneDetectorTest {
+
+  private static final String ASSET_1 = "/content/dam/asset1.jpg";
+  private static final String ASSET_2 = "/content/dam/asset2.jpg";
+  private static final String ASSET_3 = "/content/dam/asset3.jpg";
+
+  final AemContext context = new AemContext();
+
+  @BeforeEach
+  void setUp() {
+    context.create().asset(ASSET_1, 10, 10, ContentType.JPEG);
+    context.create().asset(ASSET_2, 10, 10, ContentType.JPEG);
+    context.create().asset(ASSET_3, 10, 10, ContentType.JPEG);
+  }
+
+  @Test
+  void testNoReferences() {
+    Page page = context.create().page("/content/test", null,
+        "prop1", "value1", "prop2", 5);
+    assertTrue(getReferences(page).isEmpty());
+  }
+
+  @Test
+  void testSimpleProperties() {
+    Page page = context.create().page("/content/test", null,
+        "prop1", "value1", "prop2", 5,
+        "ref1", ASSET_1, "ref2", ASSET_2);
+    assertEquals(Set.of(ASSET_1, ASSET_2), getReferences(page));
+  }
+
+  @Test
+  void testArrayProperty() {
+    Page page = context.create().page("/content/test", null,
+        "prop1", "value1", "prop2", 5,
+        "ref", ASSET_1, "refs", new String[] { ASSET_2, ASSET_3 });
+    assertEquals(Set.of(ASSET_1, ASSET_2, ASSET_3), getReferences(page));
+  }
+
+  @Test
+  void testNested() {
+    Page page = context.create().page("/content/test", null,
+        "prop1", "value1", "prop2", 5,
+        "ref", ASSET_1);
+    context.create().resource(page, "sub1",
+        "ref", ASSET_2);
+    context.create().resource(page, "sub2/sub21/sub211",
+        "ref", ASSET_3);
+    assertEquals(Set.of(ASSET_1, ASSET_2, ASSET_3), getReferences(page));
+  }
+
+  static Set<String> getReferences(@NotNull Page page) {
+    return new AssetRefereneDetector(page).getReferencedAssets().stream()
+        .map(Asset::getPath)
+        .collect(Collectors.toSet());
+  }
+
+}

--- a/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationB.java
+++ b/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationB.java
@@ -26,4 +26,6 @@ import org.apache.sling.caconfig.annotation.Configuration;
 
   String key() default "";
 
+  String imageIcon() default "";
+
 }

--- a/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationB.java
+++ b/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationB.java
@@ -26,6 +26,8 @@ import org.apache.sling.caconfig.annotation.Configuration;
 
   String key() default "";
 
-  String imageIcon() default "";
+  String assetReference1() default "";
+
+  String assetReference2() default "";
 
 }

--- a/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProviderTest.java
+++ b/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProviderTest.java
@@ -46,6 +46,7 @@ import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
 import io.wcm.testing.mock.aem.junit5.AemContextCallback;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import io.wcm.wcm.commons.contenttype.ContentType;
 
 /**
  * Test the {@link ConfigurationReferenceProvider} with the Sling CAConfig default persistence.
@@ -66,7 +67,9 @@ class ConfigurationReferenceProviderTest {
       .build();
 
   private static final ValueMap CONFIGURATION_A = new ValueMapDecorator(Map.of("key", "foo"));
-  private static final ValueMap CONFIGURATION_B = new ValueMapDecorator(Map.of("key", "bar"));
+  private static final ValueMap CONFIGURATION_B = new ValueMapDecorator(Map.of("key", "bar",
+      "assetReference1", "/content/dam/test.jpg",
+      "assetReference2", "/content/dam/test.jpg"));
   private static final Calendar TIMESTAMP = Calendar.getInstance();
 
   private Resource site1PageResource;
@@ -74,6 +77,8 @@ class ConfigurationReferenceProviderTest {
 
   @BeforeEach
   void setup() {
+    context.create().asset("/content/dam/test.jpg", 10, 10, ContentType.JPEG);
+
     context.create().resource("/conf");
 
     context.create().page("/content/region1", null, Map.of("sling:configRef", "/conf/region1"));

--- a/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider_PagePersistenceStrategyTest.java
+++ b/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider_PagePersistenceStrategyTest.java
@@ -70,7 +70,9 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
       .build();
 
   private static final ValueMap CONFIGURATION_A = new ValueMapDecorator(Map.of("key", "foo"));
-  private static final ValueMap CONFIGURATION_B = new ValueMapDecorator(Map.of("key", "bar", "imageIcon", "/content/dam/test.jpg"));
+  private static final ValueMap CONFIGURATION_B = new ValueMapDecorator(Map.of("key", "bar",
+      "assetReference1", "/content/dam/test.jpg",
+      "assetReference2", "/content/dam/test.jpg"));
   private static final Calendar TIMESTAMP = Calendar.getInstance();
 
   private Resource site1PageResource;
@@ -78,10 +80,11 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
 
   @BeforeEach
   void setup() {
-
     // enable AEM page persistence strategy
     context.registerInjectActivateService(PagePersistenceStrategy.class,
         "enabled", true);
+
+    context.create().asset("/content/dam/test.jpg", 10, 10, ContentType.JPEG);
 
     context.create().resource("/conf");
 
@@ -143,7 +146,6 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
 
   @Test
   void testReferencesOfPage2_assetReferences() {
-    context.create().asset("/content/dam/test.jpg", 10, 10, ContentType.JPEG);
     ReferenceProvider referenceProvider = context.registerInjectActivateService(ConfigurationReferenceProvider.class,
         "assetReferences", true);
     List<Reference> references = referenceProvider.findReferences(site2PageResource);
@@ -154,9 +156,6 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
         "/conf/region1/site2/sling:configs/configB",
         "/conf/global/sling:configs/configB",
         "/content/dam/test.jpg");
-    boolean hasAssetReference = references.stream()
-            .anyMatch(ref -> ref.getType().equals("asset") && ref.getResource().getPath().startsWith("/content/dam/"));
-    assertTrue(hasAssetReference, "Asset references are present");
   }
 
   @Test

--- a/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider_PagePersistenceStrategyTest.java
+++ b/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider_PagePersistenceStrategyTest.java
@@ -30,7 +30,6 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 
-import io.wcm.wcm.commons.contenttype.ContentType;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
@@ -50,6 +49,7 @@ import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
 import io.wcm.testing.mock.aem.junit5.AemContextCallback;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import io.wcm.wcm.commons.contenttype.ContentType;
 
 /**
  * Test the {@link ConfigurationReferenceProvider} with the {@link PagePersistenceStrategy}.
@@ -80,7 +80,8 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
   void setup() {
 
     // enable AEM page persistence strategy
-    context.registerInjectActivateService(new PagePersistenceStrategy(), "enabled", true);
+    context.registerInjectActivateService(PagePersistenceStrategy.class,
+        "enabled", true);
 
     context.create().resource("/conf");
 
@@ -108,8 +109,7 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
 
   @Test
   void testReferencesOfPage1() {
-    ReferenceProvider referenceProvider = new ConfigurationReferenceProvider();
-    context.registerInjectActivateService(referenceProvider);
+    ReferenceProvider referenceProvider = context.registerInjectActivateService(ConfigurationReferenceProvider.class);
     List<Reference> references = referenceProvider.findReferences(site1PageResource);
     assertReferences(references,
         "/conf/region1/site1/sling:configs/configA",
@@ -119,8 +119,7 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
 
   @Test
   void testReferencesOfPage2() {
-    ReferenceProvider referenceProvider = new ConfigurationReferenceProvider();
-    context.registerInjectActivateService(referenceProvider);
+    ReferenceProvider referenceProvider = context.registerInjectActivateService(ConfigurationReferenceProvider.class);
     List<Reference> references = referenceProvider.findReferences(site2PageResource);
     assertReferences(references,
         "/conf/region1/site2/sling:configs/configA",
@@ -131,8 +130,7 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
 
   @Test
   void testReferencesProperties() {
-    ReferenceProvider referenceProvider = new ConfigurationReferenceProvider();
-    context.registerInjectActivateService(referenceProvider);
+    ReferenceProvider referenceProvider = context.registerInjectActivateService(ConfigurationReferenceProvider.class);
     List<Reference> references = referenceProvider.findReferences(site1PageResource);
 
     // validate props of fallback config reference
@@ -146,15 +144,16 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
   @Test
   void testReferencesOfPage2_assetReferences() {
     context.create().asset("/content/dam/test.jpg", 10, 10, ContentType.JPEG);
-    ReferenceProvider referenceProvider = new ConfigurationReferenceProvider();
-    context.registerInjectActivateService(referenceProvider);
+    ReferenceProvider referenceProvider = context.registerInjectActivateService(ConfigurationReferenceProvider.class,
+        "assetReferences", true);
     List<Reference> references = referenceProvider.findReferences(site2PageResource);
 
     assertReferences(references,
-            "/conf/region1/site2/sling:configs/configA",
-            "/conf/region1/sling:configs/configA",
-            "/conf/region1/site2/sling:configs/configB",
-            "/conf/global/sling:configs/configB", "/content/dam/test.jpg");
+        "/conf/region1/site2/sling:configs/configA",
+        "/conf/region1/sling:configs/configA",
+        "/conf/region1/site2/sling:configs/configB",
+        "/conf/global/sling:configs/configB",
+        "/content/dam/test.jpg");
     boolean hasAssetReference = references.stream()
             .anyMatch(ref -> ref.getType().equals("asset") && ref.getResource().getPath().startsWith("/content/dam/"));
     assertTrue(hasAssetReference, "Asset references are present");
@@ -162,8 +161,8 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
 
   @Test
   void testDisabled() {
-    ReferenceProvider referenceProvider = new ConfigurationReferenceProvider();
-    context.registerInjectActivateService(referenceProvider, "enabled", false);
+    ReferenceProvider referenceProvider = context.registerInjectActivateService(ConfigurationReferenceProvider.class,
+        "enabled", false);
     List<Reference> references = referenceProvider.findReferences(site1PageResource);
     assertTrue(references.isEmpty(), "no references");
   }

--- a/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider_PagePersistenceStrategyTest.java
+++ b/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider_PagePersistenceStrategyTest.java
@@ -35,7 +35,6 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.testing.mock.osgi.MockOsgi;
-import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -146,8 +145,7 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
 
   @Test
   void testReferencesOfPage2_assetReferences() {
-    context.create().asset("/content/dam/test.jpg", 10, 10, ContentType.PNG);
-    //context.create().asset("/content/dam/test.jpg", 100, 100, "image/jpeg");
+    context.create().asset("/content/dam/test.jpg", 10, 10, ContentType.JPEG);
     ReferenceProvider referenceProvider = new ConfigurationReferenceProvider();
     context.registerInjectActivateService(referenceProvider);
     List<Reference> references = referenceProvider.findReferences(site2PageResource);

--- a/src/test/java/io/wcm/caconfig/extensions/references/impl/TestUtils.java
+++ b/src/test/java/io/wcm/caconfig/extensions/references/impl/TestUtils.java
@@ -19,6 +19,8 @@
  */
 package io.wcm.caconfig.extensions.references.impl;
 
+import static com.day.cq.dam.api.DamConstants.ACTIVITY_TYPE_ASSET;
+import static io.wcm.caconfig.extensions.references.impl.AssetRefereneDetector.isAssetReference;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
@@ -61,7 +63,19 @@ final class TestUtils {
   public static void assertReferences(List<Reference> references, String... paths) {
     assertEquals(paths.length, references.size(), "number of references");
     for (int i = 0; i < paths.length; i++) {
-      assertEquals(paths[i], references.get(i).getResource().getPath(), "reference #" + i);
+      Reference reference = references.get(i);
+
+      // validate path
+      String path = reference.getResource().getPath();
+      assertEquals(paths[i], path, "reference #" + i);
+
+      // validate reference type
+      if (isAssetReference(path)) {
+        assertEquals(ACTIVITY_TYPE_ASSET, reference.getType(), "reference type #" + i);
+      }
+      else {
+        assertEquals(ConfigurationReferenceProvider.REFERENCE_TYPE, reference.getType(), "reference type #" + i);
+      }
     }
   }
 


### PR DESCRIPTION
This is to solve the issue https://github.com/wcm-io/io.wcm.caconfig.editor/issues/47.

- Right now the ConfigurationReferenceProvider is called when we try to publish the page using tools --> config page 
- The `ConfigurationReferenceProvider` class is responsible to identify all the ca config references in a page
- In future we need to support all the `assets type` referenced in ca config as well as `ca config type` reference we need to provide asset references which are outdated or newly added.
- I have updated this class so that it finds both types. 