### PR TITLE
Ca config collections - showing as outdated reference when quick publishing

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.9.8" date="not released">
+      <action type="fix" dev="srikanthgurram" issue="8">
+        Saving of Context-Aware configuration collections: Update last modified date of item pages only if the configuration of it has actually changed.
+      </action>
+    </release>
+
     <release version="1.9.6" date="2024-07-08">
       <action type="update" dev="cnagel" issue="4">
         Adds context path allow list to ToolsConfigPagePersistenceStrategy configuration.

--- a/src/main/java/io/wcm/caconfig/extensions/persistence/impl/PagePersistenceStrategy.java
+++ b/src/main/java/io/wcm/caconfig/extensions/persistence/impl/PagePersistenceStrategy.java
@@ -211,7 +211,7 @@ public class PagePersistenceStrategy implements ConfigurationPersistenceStrategy
     // create new or overwrite existing children
     for (ConfigurationPersistData item : data.getItems()) {
       String path = getCollectionItemResourcePath(parentPath + "/" + item.getCollectionItemName());
-      if (isItemModifiedOrNewlyAdded(resolver, path, item)) {
+      if (isItemModifiedOrNewlyAdded(resolver, path, item, configurationManagementSettings)) {
         ensureContainingPage(resolver, path, resourceType, configurationManagementSettings);
         getOrCreateResource(resolver, path, DEFAULT_CONFIG_NODE_TYPE, item.getProperties(), configurationManagementSettings);
         updatePageLastMod(resolver, pageManager, path);

--- a/src/main/java/io/wcm/caconfig/extensions/persistence/impl/PagePersistenceStrategy.java
+++ b/src/main/java/io/wcm/caconfig/extensions/persistence/impl/PagePersistenceStrategy.java
@@ -30,6 +30,7 @@ import static io.wcm.caconfig.extensions.persistence.impl.PersistenceUtils.ensur
 import static io.wcm.caconfig.extensions.persistence.impl.PersistenceUtils.getOrCreateResource;
 import static io.wcm.caconfig.extensions.persistence.impl.PersistenceUtils.replaceProperties;
 import static io.wcm.caconfig.extensions.persistence.impl.PersistenceUtils.updatePageLastMod;
+import static io.wcm.caconfig.extensions.persistence.impl.PersistenceUtils.isItemModifiedOrNewlyAdded;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -210,9 +211,11 @@ public class PagePersistenceStrategy implements ConfigurationPersistenceStrategy
     // create new or overwrite existing children
     for (ConfigurationPersistData item : data.getItems()) {
       String path = getCollectionItemResourcePath(parentPath + "/" + item.getCollectionItemName());
-      ensureContainingPage(resolver, path, resourceType, configurationManagementSettings);
-      getOrCreateResource(resolver, path, DEFAULT_CONFIG_NODE_TYPE, item.getProperties(), configurationManagementSettings);
-      updatePageLastMod(resolver, pageManager, path);
+      if (isItemModifiedOrNewlyAdded(resolver, path, item)) {
+        ensureContainingPage(resolver, path, resourceType, configurationManagementSettings);
+        getOrCreateResource(resolver, path, DEFAULT_CONFIG_NODE_TYPE, item.getProperties(), configurationManagementSettings);
+        updatePageLastMod(resolver, pageManager, path);
+      }
     }
 
     // if resource collection parent properties are given replace them as well

--- a/src/main/java/io/wcm/caconfig/extensions/persistence/impl/PagePersistenceStrategy.java
+++ b/src/main/java/io/wcm/caconfig/extensions/persistence/impl/PagePersistenceStrategy.java
@@ -28,9 +28,9 @@ import static io.wcm.caconfig.extensions.persistence.impl.PersistenceUtils.delet
 import static io.wcm.caconfig.extensions.persistence.impl.PersistenceUtils.ensureContainingPage;
 import static io.wcm.caconfig.extensions.persistence.impl.PersistenceUtils.ensurePageIfNotContainingPage;
 import static io.wcm.caconfig.extensions.persistence.impl.PersistenceUtils.getOrCreateResource;
+import static io.wcm.caconfig.extensions.persistence.impl.PersistenceUtils.isItemModifiedOrNewlyAdded;
 import static io.wcm.caconfig.extensions.persistence.impl.PersistenceUtils.replaceProperties;
 import static io.wcm.caconfig.extensions.persistence.impl.PersistenceUtils.updatePageLastMod;
-import static io.wcm.caconfig.extensions.persistence.impl.PersistenceUtils.isItemModifiedOrNewlyAdded;
 
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;

--- a/src/main/java/io/wcm/caconfig/extensions/persistence/impl/PersistenceUtils.java
+++ b/src/main/java/io/wcm/caconfig/extensions/persistence/impl/PersistenceUtils.java
@@ -38,7 +38,6 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.api.resource.ResourceUtil;
-import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.caconfig.management.ConfigurationManagementSettings;
 import org.apache.sling.caconfig.spi.ConfigurationCollectionPersistData;
 import org.apache.sling.caconfig.spi.ConfigurationPersistData;
@@ -296,18 +295,13 @@ final class PersistenceUtils {
     if (resource == null) {
       return true; // Resource does not exist, so it is considered modified
     }
-    ValueMap valueMap = resource.getValueMap();
-    Map<String, Object> currentProperties = new HashMap<>(valueMap);
+
+    Map<String, Object> currentProperties = new HashMap<>(resource.getValueMap());
     Map<String, Object> newProperties = new HashMap<>(item.getProperties());
 
     // Filter out ignored properties
-    Set<String> currentPropertyNames = new HashSet<>(currentProperties.keySet());
-    PropertiesFilterUtil.removeIgnoredProperties(currentPropertyNames, settings);
-    currentProperties.keySet().retainAll(currentPropertyNames);
-
-    Set<String> newPropertyNames = new HashSet<>(newProperties.keySet());
-    PropertiesFilterUtil.removeIgnoredProperties(newPropertyNames, settings);
-    newProperties.keySet().retainAll(newPropertyNames);
+    PropertiesFilterUtil.removeIgnoredProperties(currentProperties, settings);
+    PropertiesFilterUtil.removeIgnoredProperties(newProperties, settings);
 
     return !currentProperties.equals(newProperties);
   }

--- a/src/main/java/io/wcm/caconfig/extensions/persistence/impl/PersistenceUtils.java
+++ b/src/main/java/io/wcm/caconfig/extensions/persistence/impl/PersistenceUtils.java
@@ -38,6 +38,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.api.resource.ResourceUtil;
+import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.caconfig.management.ConfigurationManagementSettings;
 import org.apache.sling.caconfig.spi.ConfigurationCollectionPersistData;
 import org.apache.sling.caconfig.spi.ConfigurationPersistData;
@@ -279,6 +280,34 @@ final class PersistenceUtils {
     catch (PersistenceException ex) {
       throw convertPersistenceException("Unable to persist configuration changes to " + relatedResourcePath, ex);
     }
+  }
+
+  /**
+   * Checks if the given item is modified or newly added by comparing its properties with the current state of the resource.
+   *
+   * @param resolver The ResourceResolver to access the resource.
+   * @param resourcePath The path of the resource to compare against.
+   * @param item The ConfigurationPersistData item containing the properties to compare.
+   * @return true if the resource does not exist or if any property value differs, false otherwise.
+   */
+  public static boolean isItemModifiedOrNewlyAdded(ResourceResolver resolver, String resourcePath, ConfigurationPersistData item) {
+    Resource resource = resolver.getResource(resourcePath);
+    if (resource == null) {
+      return true; // Resource does not exist, so it is considered modified
+    }
+
+    ValueMap currentProperties = resource.getValueMap();
+    Map<String, Object> itemProperties = item.getProperties();
+
+    for (Map.Entry<String, Object> entry : itemProperties.entrySet()) {
+      String key = entry.getKey();
+      Object value = entry.getValue();
+      if (!value.equals(currentProperties.get(key))) {
+        return true; // Property value differs
+      }
+    }
+
+    return false; // No differences found
   }
 
   /**

--- a/src/main/java/io/wcm/caconfig/extensions/persistence/impl/PropertiesFilterUtil.java
+++ b/src/main/java/io/wcm/caconfig/extensions/persistence/impl/PropertiesFilterUtil.java
@@ -19,6 +19,8 @@
  */
 package io.wcm.caconfig.extensions.persistence.impl;
 
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.sling.caconfig.management.ConfigurationManagementSettings;
@@ -28,13 +30,19 @@ import org.apache.sling.caconfig.management.ConfigurationManagementSettings;
  */
 final class PropertiesFilterUtil {
 
-    private PropertiesFilterUtil() {
-        // static methods only
-    }
+  private PropertiesFilterUtil() {
+    // static methods only
+  }
 
-    public static void removeIgnoredProperties(Set<String> propertyNames, ConfigurationManagementSettings settings) {
-        Set<String> ignoredProperties = settings.getIgnoredPropertyNames(propertyNames);
-        propertyNames.removeAll(ignoredProperties);
-    }
+  public static void removeIgnoredProperties(Set<String> propertyNames, ConfigurationManagementSettings settings) {
+    Set<String> ignoredProperties = settings.getIgnoredPropertyNames(propertyNames);
+    propertyNames.removeAll(ignoredProperties);
+  }
+
+  public static void removeIgnoredProperties(Map<String, Object> properties, ConfigurationManagementSettings settings) {
+    Set<String> propertyNames = new HashSet<>(properties.keySet());
+    removeIgnoredProperties(propertyNames, settings);
+    properties.keySet().retainAll(propertyNames);
+  }
 
 }

--- a/src/test/java/io/wcm/caconfig/extensions/persistence/impl/PagePersistenceStrategyTest.java
+++ b/src/test/java/io/wcm/caconfig/extensions/persistence/impl/PagePersistenceStrategyTest.java
@@ -25,14 +25,15 @@ import static io.wcm.caconfig.extensions.persistence.testcontext.PersistenceTest
 import static org.apache.sling.api.resource.ResourceResolver.PROPERTY_RESOURCE_TYPE;
 import static org.apache.sling.testing.mock.caconfig.ContextPlugins.CACONFIG;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Calendar;
 import java.util.List;
 
-import org.apache.sling.api.resource.PersistenceException;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.caconfig.ConfigurationBuilder;
 import org.apache.sling.caconfig.management.ConfigurationManager;
 import org.apache.sling.hamcrest.ResourceMatchers;
@@ -165,10 +166,8 @@ class PagePersistenceStrategyTest {
   }
 
   @Test
-  void testListConfig_updateLastModifiedIfPropertyRemoved() throws PersistenceException {
+  void testListConfig_updateLastModifiedIfPropertyRemoved() {
     context.registerInjectActivateService(new PagePersistenceStrategy(), "enabled", true);
-    ResourceResolver resourceResolver = context.resourceResolver();
-
 
     // write config
     writeConfigurationCollection(context, contentPage.getPath(), ListConfig.class.getName(), List.of(

--- a/src/test/java/io/wcm/caconfig/extensions/persistence/impl/PropertiesFilterUtilTest.java
+++ b/src/test/java/io/wcm/caconfig/extensions/persistence/impl/PropertiesFilterUtilTest.java
@@ -1,0 +1,64 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.caconfig.extensions.persistence.impl;
+
+import static io.wcm.caconfig.extensions.persistence.impl.PropertiesFilterUtil.removeIgnoredProperties;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.sling.caconfig.management.ConfigurationManagementSettings;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PropertiesFilterUtilTest {
+
+  @Mock
+  private ConfigurationManagementSettings settings;
+
+  @BeforeEach
+  void setUp() {
+    when(settings.getIgnoredPropertyNames(any())).thenReturn(Set.of("prop1", "prop3"));
+  }
+
+  @Test
+  void testRemoveIgnoredPropertiesSet() {
+    Set<String> names = new HashSet<>(Set.of("prop1", "prop2", "prop3", "prop4"));
+    removeIgnoredProperties(names, settings);
+    assertEquals(Set.of("prop2", "prop4"), names);
+  }
+
+  @Test
+  void testRemoveIgnoredPropertiesMap() {
+    Map<String, Object> properties = new HashMap<>(Map.of("prop1", 1, "prop2", 2, "prop3", 3, "prop4", 4));
+    removeIgnoredProperties(properties, settings);
+    assertEquals(Map.of("prop2", 2, "prop4", 4), properties);
+  }
+
+}


### PR DESCRIPTION
This is to solve https://github.com/wcm-io/io.wcm.caconfig.editor/issues/48

Below is the behaviour of nested configurations :

Current behaviour: When we update or add one config in nested config all the configs inside the nested configs last modified dates are updated.
Expect behaviour: When we update or add a single config in nested config only the config that is added or updated should have last modified date updated