### PR TITLE
AEM Page persistence strategy: Add OSGi configuration property "Config Name Deny List"

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -25,7 +25,7 @@
   <body>
 
     <release version="1.10.4" date="not released">
-      <action type="update" dev="sseifert">
+      <action type="update" dev="sseifert" issue="11">
         AEM Page persistence strategy: Add OSGi configuration property "Config Name Deny List" which allows to configure a list of configuration names that should not be persisted as AEM pages.
         By default, this contains the configuration name com.adobe.aem.wcm.site.manager.config.SiteConfig, which is accessed internally by AEM using JCR queries and assuming a simplified persistence structure.
       </action>

--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,13 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
+    <release version="1.10.4" date="not released">
+      <action type="update" dev="sseifert">
+        AEM Page persistence strategy: Add OSGi configuration property "Config Name Deny List" which allows to configure a list of configuration names that should not be persisted as AEM pages.
+        By default, this contains the configuration name com.adobe.aem.wcm.site.manager.config.SiteConfig, which is accessed internally by AEM using JCR queries and assuming a simplified persistence structure.
+      </action>
+    </release>
+
     <release version="1.10.2" date="2025-01-13">
       <action type="fix" dev="sseifert" issue="9">
         AEM Page persistence strategy: Saving of Context-Aware configuration collections - restore previous behavior of setting last modified date of all items regardless of actual data changes or not.

--- a/src/test/java/io/wcm/caconfig/extensions/persistence/impl/PagePersistenceStrategyTest.java
+++ b/src/test/java/io/wcm/caconfig/extensions/persistence/impl/PagePersistenceStrategyTest.java
@@ -33,10 +33,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Calendar;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.caconfig.ConfigurationBuilder;
 import org.apache.sling.caconfig.management.ConfigurationManager;
 import org.apache.sling.hamcrest.ResourceMatchers;
@@ -114,25 +112,6 @@ class PagePersistenceStrategyTest {
     config = contentPage.getContentResource().adaptTo(ConfigurationBuilder.class).as(SimpleConfig.class);
     assertNull(config.stringParam());
     assertEquals(5, config.intParam());
-  }
-
-  @Test
-  void testSimpleConfig_Disabled() {
-    context.registerInjectActivateService(PagePersistenceStrategy.class, "enabled", false);
-
-    // write config
-    writeConfiguration(context, contentPage.getPath(), SimpleConfig.class.getName(),
-        "stringParam", "value1",
-        "intParam", 123);
-
-    // assert storage in page in /conf
-    Page configPage = context.pageManager().getPage("/conf/test/site1/sling:configs/" + SimpleConfig.class.getName());
-    assertNull(configPage);
-
-    // read config
-    SimpleConfig config = contentPage.getContentResource().adaptTo(ConfigurationBuilder.class).as(SimpleConfig.class);
-    assertEquals("value1", config.stringParam());
-    assertEquals(123, config.intParam());
   }
 
   @Test
@@ -457,56 +436,81 @@ class PagePersistenceStrategyTest {
   }
 
   @Test
-  void testSimpleConfig_DeniedConfigName() {
-    String configName = "deniedConfigName";
-    context.registerInjectActivateService(PagePersistenceStrategy.class, "enabled", true,
-        "configNameDenyList", new String[] { configName });
-
-    // write config
-    writeConfiguration(context, contentPage.getPath(), configName,
-        "param1", "value1");
-
-    // assert storage in page in /conf
-    Resource configResource = context.resourceResolver().getResource("/conf/test/site1/sling:configs/" + configName);
-    assertThat(configResource, ResourceMatchers.props("param1", "value1"));
-
-    // read config
-    ValueMap configMap = contentPage.getContentResource().adaptTo(ConfigurationBuilder.class).name(configName).asValueMap();
-    assertEquals("value1", configMap.get("param1", String.class));
-
-    // delete
-    ConfigurationManager configManager = context.getService(ConfigurationManager.class);
-    configManager.deleteConfiguration(contentPage.getContentResource(), configName);
-    configMap = contentPage.getContentResource().adaptTo(ConfigurationBuilder.class).name(configName).asValueMap();
-    assertNull(configMap.get("param1", String.class));
+  void testSimpleConfig_Disabled() {
+    context.registerInjectActivateService(PagePersistenceStrategy.class, "enabled", false);
+    doTestSimpleConfig_DisabledOrDenied();
   }
 
   @Test
-  void testListConfig_DeniedConfigName() {
-    String configName = "deniedListConfigName";
+  void testSimpleConfig_Denied() {
     context.registerInjectActivateService(PagePersistenceStrategy.class, "enabled", true,
-        "configNameDenyList", new String[] { configName });
+        "configNameDenyList", new String[] { SimpleConfig.class.getName() });
+    doTestSimpleConfig_DisabledOrDenied();
+  }
 
+  void doTestSimpleConfig_DisabledOrDenied() {
     // write config
-    writeConfigurationCollection(context, contentPage.getPath(), configName, List.of(
-        ImmutableValueMap.of("stringParam", "value1"),
-        ImmutableValueMap.of("stringParam", "value2"), Map.of()));
+    writeConfiguration(context, contentPage.getPath(), SimpleConfig.class.getName(),
+        "stringParam", "value1",
+        "intParam", 123);
 
     // assert storage in page in /conf
-    Resource parentResource = context.resourceResolver().getResource("/conf/test/site1/sling:configs/" + configName);
-    assertNotNull(parentResource);
-
-    Resource configResource1 = context.resourceResolver().getResource("/conf/test/site1/sling:configs/" + configName + "/item0");
-    assertThat(configResource1, ResourceMatchers.props("stringParam", "value1"));
-
-    Resource configResource2 = context.resourceResolver().getResource("/conf/test/site1/sling:configs/" + configName + "/item1");
-    assertThat(configResource2, ResourceMatchers.props("stringParam", "value2"));
+    Page configPage = context.pageManager().getPage("/conf/test/site1/sling:configs/" + SimpleConfig.class.getName());
+    assertNull(configPage);
 
     // read config
-    List<ValueMap> configs = List.copyOf(contentPage.getContentResource().adaptTo(ConfigurationBuilder.class).name(configName).asValueMapCollection());
-    ValueMap config1 = configs.get(0);
-    assertEquals("value1", config1.get("stringParam", String.class));
-    ValueMap config2 = configs.get(1);
-    assertEquals("value2", config2.get("stringParam", String.class));
+    SimpleConfig config = contentPage.getContentResource().adaptTo(ConfigurationBuilder.class).as(SimpleConfig.class);
+    assertEquals("value1", config.stringParam());
+    assertEquals(123, config.intParam());
+
+    // delete
+    ConfigurationManager configManager = context.getService(ConfigurationManager.class);
+    configManager.deleteConfiguration(contentPage.getContentResource(), SimpleConfig.class.getName());
+    config = contentPage.getContentResource().adaptTo(ConfigurationBuilder.class).as(SimpleConfig.class);
+    assertNull(config.stringParam());
+    assertEquals(5, config.intParam());
   }
+
+  @Test
+  void testListConfig_Disabled() {
+    context.registerInjectActivateService(PagePersistenceStrategy.class, "enabled", false);
+    doTestListConfig_DisabledOrDenied();
+  }
+
+  @Test
+  void testListConfig_Denied() {
+    context.registerInjectActivateService(PagePersistenceStrategy.class, "enabled", true,
+        "configNameDenyList", new String[] { ListConfig.class.getName() });
+    doTestListConfig_DisabledOrDenied();
+  }
+
+  void doTestListConfig_DisabledOrDenied() {
+    // write config
+    writeConfigurationCollection(context, contentPage.getPath(), ListConfig.class.getName(), List.of(
+        ImmutableValueMap.of("stringParam", "value1", "intParam", 123),
+        ImmutableValueMap.of("stringParam", "value2", "intParam", 234)),
+        ImmutableValueMap.of("sling:configCollectionInherit", true));
+
+    // assert storage in page in /conf
+    Resource parentResource = context.resourceResolver().getResource("/conf/test/site1/sling:configs/" + ListConfig.class.getName());
+    assertNotNull(parentResource);
+    assertTrue(parentResource.getValueMap().get("sling:configCollectionInherit", false));
+
+    Resource configResource1 = context.resourceResolver().getResource("/conf/test/site1/sling:configs/" + ListConfig.class.getName() + "/item0");
+    assertThat(configResource1, ResourceMatchers.props("stringParam", "value1", "intParam", 123));
+
+    Resource configResource2 = context.resourceResolver().getResource("/conf/test/site1/sling:configs/" + ListConfig.class.getName() + "/item1");
+    assertThat(configResource2, ResourceMatchers.props("stringParam", "value2", "intParam", 234));
+
+    // read config
+    List<ListConfig> configs = List.copyOf(contentPage.getContentResource().adaptTo(ConfigurationBuilder.class).asCollection(ListConfig.class));
+    assertEquals(2, configs.size());
+    ListConfig config1 = configs.get(0);
+    assertEquals("value1", config1.stringParam());
+    assertEquals(123, config1.intParam());
+    ListConfig config2 = configs.get(1);
+    assertEquals("value2", config2.stringParam());
+    assertEquals(234, config2.intParam());
+  }
+
 }


### PR DESCRIPTION
which allows to configure a list of configuration names that should not be persisted as AEM pages

By default, this contains the configuration name `com.adobe.aem.wcm.site.manager.config.SiteConfig`, which is accessed internally by AEM using JCR queries and assuming a simplified persistence structure.

Fixes https://github.com/wcm-io/io.wcm.caconfig.editor/issues/46