### PR TITLE
Extend ConfigurationReferenceProvider in order to ignore specific resource types.

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
+    <release version="1.10.5" date="not released">
+      <action type="update" dev="mpankratiev" issue="22">
+        Configuration Reference Provider: Extend configuration with "Ignore Resource Types" to be able to skip references collection for the specific resource types.
+      </action>
+    </release>
+
     <release version="1.10.4" date="2025-02-19">
       <action type="update" dev="sseifert" issue="11">
         AEM Page persistence strategy: Add OSGi configuration property "Config Name Deny List" which allows to configure a list of configuration names that should not be persisted as AEM pages.

--- a/changes.xml
+++ b/changes.xml
@@ -24,8 +24,8 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
-    <release version="1.10.5" date="not released">
-      <action type="update" dev="mpankratiev" issue="22">
+    <release version="1.11.0" date="not released">
+      <action type="add" dev="mpankratiev" issue="22">
         Configuration Reference Provider: Extend configuration with "Ignore Resource Types" to be able to skip references collection for the specific resource types.
       </action>
     </release>

--- a/changes.xml
+++ b/changes.xml
@@ -26,7 +26,7 @@
 
     <release version="1.11.0" date="not released">
       <action type="add" dev="mpankratiev" issue="22">
-        Configuration Reference Provider: Extend configuration with "Ignore Resource Types" to be able to skip references collection for the specific resource types.
+        Configuration Reference Provider: Extend configuration with "Context Page Resource Type Allow List" and "Context Page Resource Type Deny List" to be able to allow or skip references collection for the specific context page resource types.
       </action>
     </release>
 

--- a/src/main/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider.java
+++ b/src/main/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -109,7 +110,7 @@ public class ConfigurationReferenceProvider implements ReferenceProvider {
 
   private boolean enabled;
   private boolean assetReferencesEnabled;
-  private List<String> ignoreResourceTypes;
+  private Set<String> ignoreResourceTypes;
 
   private static final Logger log = LoggerFactory.getLogger(ConfigurationReferenceProvider.class);
 
@@ -120,7 +121,7 @@ public class ConfigurationReferenceProvider implements ReferenceProvider {
   protected void activate(Config config) {
     enabled = config.enabled();
     assetReferencesEnabled = config.assetReferences();
-    ignoreResourceTypes = List.of(config.ignoreResourceTypes());
+    ignoreResourceTypes = new HashSet<>(List.of(config.ignoreResourceTypes())); // ignore duplicates
   }
 
   @Deactivate

--- a/src/main/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider.java
+++ b/src/main/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider.java
@@ -91,6 +91,9 @@ public class ConfigurationReferenceProvider implements ReferenceProvider {
         description = "Check for asset references within the context-aware configurations, and add them to the list of references.")
     boolean assetReferences() default false;
 
+    @AttributeDefinition(name = "Ignore Resource Types",
+        description = "Check for the resource type of the page and returns empty list of references if resource type is found.")
+    String[] ignoreResourceTypes() default {};
   }
 
   static final String REFERENCE_TYPE = "caconfig";
@@ -106,6 +109,7 @@ public class ConfigurationReferenceProvider implements ReferenceProvider {
 
   private boolean enabled;
   private boolean assetReferencesEnabled;
+  private List<String> ignoreResourceTypes;
 
   private static final Logger log = LoggerFactory.getLogger(ConfigurationReferenceProvider.class);
 
@@ -116,6 +120,7 @@ public class ConfigurationReferenceProvider implements ReferenceProvider {
   protected void activate(Config config) {
     enabled = config.enabled();
     assetReferencesEnabled = config.assetReferences();
+    ignoreResourceTypes = List.of(config.ignoreResourceTypes());
   }
 
   @Deactivate
@@ -135,6 +140,10 @@ public class ConfigurationReferenceProvider implements ReferenceProvider {
     }
     Page contextPage = pageManager.getContainingPage(resource);
     if (contextPage == null) {
+      return Collections.emptyList();
+    }
+
+    if (ignoreResourceTypes.contains(contextPage.getContentResource().getResourceType())) {
       return Collections.emptyList();
     }
 

--- a/src/main/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider.java
+++ b/src/main/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider.java
@@ -92,9 +92,14 @@ public class ConfigurationReferenceProvider implements ReferenceProvider {
         description = "Check for asset references within the context-aware configurations, and add them to the list of references.")
     boolean assetReferences() default false;
 
-    @AttributeDefinition(name = "Ignore Resource Types",
-        description = "Check for the resource type of the page and returns empty list of references if resource type is found.")
-    String[] ignoreResourceTypes() default {};
+    @AttributeDefinition(name = "Context Page Resource Type Deny List",
+        description = "Context pages with any of these page content resource types are ignored by the reference provice.")
+    String[] contextPageResourceTypeDenyList() default {};
+
+    @AttributeDefinition(name = "Context Page Resource Type Allow List",
+        description = "The reference provider only gets active for context pages with any of these page content resource types. "
+            + "If the list is empty, it's active for all resource types.")
+    String[] contextPageResourceTypeAllowList() default {};
   }
 
   static final String REFERENCE_TYPE = "caconfig";
@@ -110,7 +115,8 @@ public class ConfigurationReferenceProvider implements ReferenceProvider {
 
   private boolean enabled;
   private boolean assetReferencesEnabled;
-  private Set<String> ignoreResourceTypes;
+  private Set<String> contextPageResourceTypeDenyList;
+  private Set<String> contextPageResourceTypeAllowList;
 
   private static final Logger log = LoggerFactory.getLogger(ConfigurationReferenceProvider.class);
 
@@ -121,7 +127,8 @@ public class ConfigurationReferenceProvider implements ReferenceProvider {
   protected void activate(Config config) {
     enabled = config.enabled();
     assetReferencesEnabled = config.assetReferences();
-    ignoreResourceTypes = new HashSet<>(List.of(config.ignoreResourceTypes())); // ignore duplicates
+    contextPageResourceTypeDenyList = new HashSet<>(List.of(config.contextPageResourceTypeDenyList()));
+    contextPageResourceTypeAllowList = new HashSet<>(List.of(config.contextPageResourceTypeAllowList()));
   }
 
   @Deactivate
@@ -140,11 +147,7 @@ public class ConfigurationReferenceProvider implements ReferenceProvider {
       throw new RuntimeException("No page manager.");
     }
     Page contextPage = pageManager.getContainingPage(resource);
-    if (contextPage == null) {
-      return Collections.emptyList();
-    }
-
-    if (ignoreResourceTypes.contains(contextPage.getContentResource().getResourceType())) {
+    if (contextPage == null || !shouldProcessContextPage(contextPage)) {
       return Collections.emptyList();
     }
 
@@ -181,6 +184,19 @@ public class ConfigurationReferenceProvider implements ReferenceProvider {
 
     log.debug("Found {} references for resource {}", references.size(), resource.getPath());
     return references;
+  }
+
+  /**
+   * Check resource type of context page against allow/deny lists.
+   * @param contextPage Context page
+   * @return true if context page should be processed
+   */
+  private boolean shouldProcessContextPage(@NotNull Page contextPage) {
+    String resourceType = contextPage.getContentResource().getResourceType();
+    if (contextPageResourceTypeDenyList.contains(resourceType)) {
+      return false;
+    }
+    return (contextPageResourceTypeAllowList.isEmpty() || contextPageResourceTypeAllowList.contains(resourceType));
   }
 
   private Collection<Page> getReferencePages(@Nullable Iterator<Resource> configurationInheritanceChain, @NotNull PageManager pageManager) {

--- a/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider_PagePersistenceStrategyTest.java
+++ b/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider_PagePersistenceStrategyTest.java
@@ -24,13 +24,13 @@ import static io.wcm.caconfig.extensions.references.impl.TestUtils.assertReferen
 import static io.wcm.caconfig.extensions.references.impl.TestUtils.registerConfigurations;
 import static org.apache.sling.testing.mock.caconfig.ContextPlugins.CACONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
@@ -75,11 +75,13 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
       "assetReference1", "/content/dam/test.jpg",
       "assetReference2", "/content/dam/test.jpg"));
   private static final Calendar TIMESTAMP = Calendar.getInstance();
-  private static final String RESOURCE_TYPE_TO_IGNORE = "mysite/components/ignored";
+
+  private static final String RESOURCE_TYPE_DENIED = "mysite/components/deny";
+  private static final String RESOURCE_TYPE_ALLOWED = "mysite/components/allow";
+  private static final String RESOURCE_TYPE_OTHER = "mysite/components/other";
 
   private Resource site1PageResource;
   private Resource site2PageResource;
-  private Resource site2IgnoredResource;
 
   @BeforeEach
   void setup() {
@@ -97,11 +99,9 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
     Page region1Page = context.create().page("/content/region1/page");
     Page site1Page = context.create().page("/content/region1/site1/page");
     Page site2Page = context.create().page("/content/region1/site2/page");
-    Page site2IgnoredPage = context.create().page("/content/region1/site2/page2", StringUtils.EMPTY, Map.of("sling:resourceType", RESOURCE_TYPE_TO_IGNORE));
 
     site1PageResource = site1Page.adaptTo(Resource.class);
     site2PageResource = site2Page.adaptTo(Resource.class);
-    site2IgnoredResource = site2IgnoredPage.adaptTo(Resource.class);
 
     registerConfigurations(context, ConfigurationA.class, ConfigurationB.class);
 
@@ -164,11 +164,45 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
   }
 
   @Test
-  void testReferencesOfIgnoredPage() {
-    ReferenceProvider referenceProvider = context.registerInjectActivateService(ConfigurationReferenceProvider.class, "ignoreResourceTypes", new String[] {RESOURCE_TYPE_TO_IGNORE});
-    List<Reference> references = referenceProvider.findReferences(site2IgnoredResource);
+  void testReferencesOfDeniedContextPageResourceType() {
+    ReferenceProvider referenceProvider = context.registerInjectActivateService(ConfigurationReferenceProvider.class,
+        "contextPageResourceTypeDenyList", new String[] { RESOURCE_TYPE_DENIED });
+
+    Page page = context.create().page("/content/region1/site2/page2", null,
+        "sling:resourceType", RESOURCE_TYPE_DENIED);
+    Resource resource = page.adaptTo(Resource.class);
+
+    List<Reference> references = referenceProvider.findReferences(resource);
 
     assertTrue(references.isEmpty(), "no references");
+  }
+
+  @Test
+  void testReferencesOfNotAllowedContextPageResourceType() {
+    ReferenceProvider referenceProvider = context.registerInjectActivateService(ConfigurationReferenceProvider.class,
+        "contextPageResourceTypeAllowList", new String[] { RESOURCE_TYPE_ALLOWED });
+
+    Page page = context.create().page("/content/region1/site2/page2", null,
+        "sling:resourceType", RESOURCE_TYPE_OTHER);
+    Resource resource = page.adaptTo(Resource.class);
+
+    List<Reference> references = referenceProvider.findReferences(resource);
+
+    assertTrue(references.isEmpty(), "no references");
+  }
+
+  @Test
+  void testReferencesOfAllowedContextPageResourceType() {
+    ReferenceProvider referenceProvider = context.registerInjectActivateService(ConfigurationReferenceProvider.class,
+        "contextPageResourceTypeAllowList", new String[] { RESOURCE_TYPE_ALLOWED });
+
+    Page page = context.create().page("/content/region1/site2/page2", null,
+        "sling:resourceType", RESOURCE_TYPE_ALLOWED);
+    Resource resource = page.adaptTo(Resource.class);
+
+    List<Reference> references = referenceProvider.findReferences(resource);
+
+    assertFalse(references.isEmpty(), "has references");
   }
 
   @Test

--- a/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider_PagePersistenceStrategyTest.java
+++ b/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider_PagePersistenceStrategyTest.java
@@ -30,6 +30,7 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
@@ -74,9 +75,11 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
       "assetReference1", "/content/dam/test.jpg",
       "assetReference2", "/content/dam/test.jpg"));
   private static final Calendar TIMESTAMP = Calendar.getInstance();
+  private static String RESOURCE_TYPE_TO_IGNORE = "mysite/components/ignored";
 
   private Resource site1PageResource;
   private Resource site2PageResource;
+  private Resource site2IgnoredResource;
 
   @BeforeEach
   void setup() {
@@ -94,9 +97,11 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
     Page region1Page = context.create().page("/content/region1/page");
     Page site1Page = context.create().page("/content/region1/site1/page");
     Page site2Page = context.create().page("/content/region1/site2/page");
+    Page site2IgnoredPage = context.create().page("/content/region1/site2/page2", StringUtils.EMPTY, Map.of("sling:resourceType", RESOURCE_TYPE_TO_IGNORE));
 
     site1PageResource = site1Page.adaptTo(Resource.class);
     site2PageResource = site2Page.adaptTo(Resource.class);
+    site2IgnoredResource = site2IgnoredPage.adaptTo(Resource.class);
 
     registerConfigurations(context, ConfigurationA.class, ConfigurationB.class);
 
@@ -156,6 +161,14 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
         "/conf/region1/site2/sling:configs/configB",
         "/conf/global/sling:configs/configB",
         "/content/dam/test.jpg");
+  }
+
+  @Test
+  void testReferencesOfIgnoredPage() {
+    ReferenceProvider referenceProvider = context.registerInjectActivateService(ConfigurationReferenceProvider.class, "ignoreResourceTypes", new String[] {RESOURCE_TYPE_TO_IGNORE});
+    List<Reference> references = referenceProvider.findReferences(site2IgnoredResource);
+
+    assertTrue(references.isEmpty(), "no references");
   }
 
   @Test

--- a/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider_PagePersistenceStrategyTest.java
+++ b/src/test/java/io/wcm/caconfig/extensions/references/impl/ConfigurationReferenceProvider_PagePersistenceStrategyTest.java
@@ -75,7 +75,7 @@ class ConfigurationReferenceProvider_PagePersistenceStrategyTest {
       "assetReference1", "/content/dam/test.jpg",
       "assetReference2", "/content/dam/test.jpg"));
   private static final Calendar TIMESTAMP = Calendar.getInstance();
-  private static String RESOURCE_TYPE_TO_IGNORE = "mysite/components/ignored";
+  private static final String RESOURCE_TYPE_TO_IGNORE = "mysite/components/ignored";
 
   private Resource site1PageResource;
   private Resource site2PageResource;


### PR DESCRIPTION
temporary draft PR to get sonar checks for external contribution